### PR TITLE
Fix race condition where instance messages were lost

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom-social-firebase",
   "description": "Firebase Social Provider for freedomjs",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/freedomjs/freedom-social-firebase.git"

--- a/src/firebase-social-provider.js
+++ b/src/firebase-social-provider.js
@@ -185,13 +185,13 @@ FirebaseSocialProvider.prototype.addUserProfile_ = function(friend) {
   var myRefForFriend = new Firebase(
       this.baseUrl_ + '/' + this.networkName_ + ':' + this.getUserId_() +
       '/friends/' + this.networkName_ + ':' + friend.userId);
-  myRefForFriend.set({isFriend: true});
+  // use update, not set, to preserve existing data
+  myRefForFriend.update({isFriend: true});
 
   // Initialize an inbox, writable only by my friend, and unique to this
   // agent (client).  This should be cleared when I disconnect.
   var myInboxForFriendRef = myRefForFriend.child(
       'inbox/' + this.loginState_.agent);
-  myInboxForFriendRef.set('empty');
   myInboxForFriendRef.onDisconnect().remove();
 
   // Monitor my new inbox.


### PR DESCRIPTION
Fix race condition where instance messages were lost.  Fixes https://github.com/uProxy/uproxy/issues/1298

The problem was that upon login we immediately broadcast our client as being ONLINE, even before we setup an inbox for each friend to write to.  This means that friends can send us instance messages before we have an inbox setup for them.

Previously, when creating an inbox for a friend, we cleared any existing data for that friend.  Now we still create an inbox at the same time, but don't initialize it to empty.  This ensures that messages received before the inbox is created can still be read.

Tested in uProxy using Facebook social provider
