### PR TITLE
Remove callbacks on logout, emit OFFLINE client state for users who disconnect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom-social-firebase",
   "description": "Firebase Social Provider for freedomjs",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/freedomjs/freedom-social-firebase.git"

--- a/src/firebase-social-provider.js
+++ b/src/firebase-social-provider.js
@@ -13,7 +13,8 @@ Firebase.INTERNAL.forceWebSockets();
  * - a .getMyUserProfile_ method, which returns the logged in user's profile.
  */
 var FirebaseSocialProvider = function() {
-  this.onCallbacks_ = [];  // Array of {ref, eventType, callback} objects.
+  // Array of {ref :FirebaseRef, eventType :string, callback :Function} objects.
+  this.onCallbacks_ = [];
 };
 
 /*

--- a/src/firebase-social-provider.js
+++ b/src/firebase-social-provider.js
@@ -246,8 +246,8 @@ FirebaseSocialProvider.prototype.addUserProfile_ = function(friend) {
   clients.on('child_added', function(snapshot) {
     var clientId = friend.userId + '/' + snapshot.key();
     // Some old versions of uProxy (before 4/24/15) set the status to 'OFFLINE'.
-    // We can assume all clients are ONLINE once those versions of uProxy
-    // are no longer in use.
+    // TODO: change to assume ONLINE when old versions of uProxy are no longer
+    // in use.
     var status = snapshot.val() == 'ONLINE' ? 'ONLINE' : 'OFFLINE';
     this.addOrUpdateClient_(friend.userId, clientId, status);
   }.bind(this));

--- a/src/firebase-social-provider.js
+++ b/src/firebase-social-provider.js
@@ -245,11 +245,7 @@ FirebaseSocialProvider.prototype.addUserProfile_ = function(friend) {
   var clients = new Firebase(this.getClientsUrl_(friend.userId));
   clients.on('child_added', function(snapshot) {
     var clientId = friend.userId + '/' + snapshot.key();
-    // Some old versions of uProxy (before 4/24/15) set the status to 'OFFLINE'.
-    // TODO: change to assume ONLINE when old versions of uProxy are no longer
-    // in use.
-    var status = snapshot.val() == 'ONLINE' ? 'ONLINE' : 'OFFLINE';
-    this.addOrUpdateClient_(friend.userId, clientId, status);
+    this.addOrUpdateClient_(friend.userId, clientId, 'ONLINE');
   }.bind(this));
   clients.on('child_removed', function(snapshot) {
     var clientId = friend.userId + '/' + snapshot.key();


### PR DESCRIPTION
- Fix for https://github.com/uProxy/uproxy/issues/1395.  Now we disconnect all handlers upon logout.
- Fix for https://github.com/uProxy/uproxy/issues/1299.  Now users who are OFFLINE will always remove their client record, regardless of whether they logout (through a call to .logout()) or disconnect (e.g. quit their browser).  We now listen to child_added and child_removed events, and can detect OFFLINE clients when we get a child_removed.

Tested in uProxy in Chrome.
