### PR TITLE
Incremement version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom-social-firebase",
   "description": "Firebase Social Provider for freedomjs",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "repository": {
     "type": "git",
     "url": "https://github.com/freedomjs/freedom-social-firebase.git"


### PR DESCRIPTION
freedom-social-firebase 0.0.11 had a bad build (firebase.js was missing, causing Facebook to be completely broken).  0.0.12 fixes this (includes firebase.js in the dist/ directory)
