### PR TITLE
Detect disconnect in Firebase social providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom-social-firebase",
   "description": "Firebase Social Provider for freedomjs",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "repository": {
     "type": "git",
     "url": "https://github.com/freedomjs/freedom-social-firebase.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom-social-firebase",
   "description": "Firebase Social Provider for freedomjs",
-  "version": "0.0.13",
+  "version": "1.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/freedomjs/freedom-social-firebase.git"

--- a/src/firebase-social-provider.js
+++ b/src/firebase-social-provider.js
@@ -65,7 +65,7 @@ FirebaseSocialProvider.prototype.login = function(loginOpts) {
         };
 
         this.setPresence_(true);
-        this.detectDisconnect_();
+        this.setupDetectDisconnect_();
 
         // Emits my ClientState.
         var myClientState = this.addOrUpdateMyClient_('ONLINE');
@@ -359,9 +359,9 @@ FirebaseSocialProvider.prototype.on_ = function(ref, eventType, callback) {
 };
 
 
-FirebaseSocialProvider.prototype.detectDisconnect_ = function() {
+FirebaseSocialProvider.prototype.setupDetectDisconnect_ = function() {
   if (!this.loginState_) {
-    throw 'Error in FirebaseSocialProvider.detectDisconnect_: not logged in';
+    throw 'FirebaseSocialProvider.setupDetectDisconnect_: not logged in';
   }
   var connectedRef = new Firebase(this.baseUrl_ + '.info/connected');
   this.on_(connectedRef, 'value', function(snapshot) {


### PR DESCRIPTION
Detect disconnect in Firebase social providers.  This is using Firebase's special .info/connected endpoint, documented at https://www.firebase.com/docs/web/guide/offline-capabilities.html

Also I've changed this.baseRef_ to be the reference to the top-level Firebase app (e.g. https://popping-heat-4874.firebaseio.com/ for uProxy), and added this.allUsersUrl_ to be what baseRef_ used to represent (e.g. https://popping-heat-4874.firebaseio.com/facebook-users for uProxy with Facebook)

Fixes https://github.com/freedomjs/freedom-social-firebase/issues/10 and https://github.com/uProxy/uproxy/issues/1392

Tested in Chrome (uProxy automatically reconnects) and Firefox (reconnect not implemented but uProxy successfully detects the disconnect)
