### PR TITLE
Attempt to re-use last access token for Facebook if !interactive

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom-social-firebase",
   "description": "Firebase Social Provider for freedomjs",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/freedomjs/freedom-social-firebase.git"

--- a/src/facebook-social-provider.js
+++ b/src/facebook-social-provider.js
@@ -9,7 +9,31 @@ FacebookSocialProvider.prototype = new FirebaseSocialProvider();
 /*
  * Returns a Promise which fulfills with an OAuth token.
  */
-FacebookSocialProvider.prototype.getOAuthToken_ = function() {
+FacebookSocialProvider.prototype.getOAuthToken_ = function(loginOpts) {
+  if (loginOpts.interactive) {
+    return this.getOAuthTokenInteractive_(loginOpts);
+  }
+
+  // For non-interactive logins, attempt to re-use the last accessToken if it
+  // is still valid.  If not default to interactive login behavior.
+  return this.storage.get('FacebookSocialProvider-last-access-token').then(
+      function(lastAccessToken) {
+    return this.isValidToken_(lastAccessToken).then(function(isValid) {
+      if (isValid) {
+        return lastAccessToken;
+      } else {
+        return this.getOAuthTokenInteractive_(loginOpts);
+      }
+    }.bind(this));
+  }.bind(this));
+};
+
+/*
+ * Launches an interactive Facebook OAuth login.
+ * Returns a Promise which fulfills with an OAuth token.
+ */
+FacebookSocialProvider.prototype.getOAuthTokenInteractive_ =
+    function(loginOpts) {
   var OAUTH_REDIRECT_URLS = [
     "https://www.uproxy.org/oauth-redirect-uri",
     "https://fmdppkkepalnkeommjadgbhiohihdhii.chromiumapp.org/",
@@ -29,8 +53,12 @@ FacebookSocialProvider.prototype.getOAuthToken_ = function() {
                 "&response_type=token";
     return oauth.launchAuthFlow(url, stateObj);
   }).then(function(responseUrl) {
-    return responseUrl.match(/access_token=([^&]+)/)[1];
-  }).catch(function (err) {
+    var accessToken = responseUrl.match(/access_token=([^&]+)/)[1];
+    if (loginOpts.rememberLogin) {
+      this.storage.set('FacebookSocialProvider-last-access-token', accessToken);
+    }
+    return accessToken;
+  }.bind(this)).catch(function (err) {
     return Promise.reject('Login error: ' + err.message);
   });
 };
@@ -104,6 +132,30 @@ FacebookSocialProvider.prototype.facebookGet_ = function(endPoint) {
     // TODO: error checking
     xhr.onload = function() {
       fulfill(JSON.parse(this.response));
+    };
+    xhr.send();
+  });
+};
+
+/*
+ * Returns a Promise<boolean> that fulfills with true iff token is still valid.
+ */
+FacebookSocialProvider.prototype.isValidToken_ = function(token) {
+  return new Promise(function(fulfill, reject) {
+    if (!token) {
+      fulfill(false);
+      return;
+    }
+    var xhr = new XMLHttpRequest();
+    var url = 'https://graph.facebook.com/v2.1/me?access_token=' + token +
+        '&format=json&redirect=false';
+    xhr.open('GET', url);
+    xhr.onload = function() {
+      if (JSON.parse(this.response).error) {
+        fulfill(false);
+      } else {
+        fulfill(true);
+      }
     };
     xhr.send();
   });

--- a/src/firebase-social-provider.js
+++ b/src/firebase-social-provider.js
@@ -15,6 +15,8 @@ Firebase.INTERNAL.forceWebSockets();
 var FirebaseSocialProvider = function() {
   // Array of {ref :FirebaseRef, eventType :string, callback :Function} objects.
   this.onCallbacks_ = [];
+
+  this.storage = freedom['core.storage']();
 };
 
 /*
@@ -48,7 +50,7 @@ FirebaseSocialProvider.prototype.login = function(loginOpts) {
   var allUsersRef = new Firebase(this.allUsersUrl_);
 
   return new Promise(function(fulfillLogin, rejectLogin) {
-    this.getOAuthToken_().then(function(token) {
+    this.getOAuthToken_(loginOpts).then(function(token) {
       allUsersRef.authWithOAuthToken(this.networkName_, token,
           function(error, authData) {
         if (error) {

--- a/src/social.firebase-facebook.json
+++ b/src/social.firebase-facebook.json
@@ -15,6 +15,7 @@
   ],
   "permissions": [
     "core.websocket",
-    "core.oauth"
+    "core.oauth",
+    "core.storage"
   ]
 }

--- a/src/social.firebase-google.json
+++ b/src/social.firebase-google.json
@@ -15,6 +15,7 @@
   ],
   "permissions": [
     "core.websocket",
-    "core.oauth"
+    "core.oauth",
+    "core.storage"
   ]
 }


### PR DESCRIPTION
Fixes https://github.com/uProxy/uproxy/issues/1672

If loginOpts.interactive is false, we will attempt to re-use the last Facebook access_token if it is still valid.  If it is not still valid, we will continue launching the OAuth flow to get a new access_token

Tested in Chrome
