### PR TITLE
Set interactive param on oauth provider for reconnect

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "freedom": "^0.6.26",
     "freedom-for-chrome": "^0.4.20",
-    "freedom-for-firefox": "^0.6.15",
+    "freedom-for-firefox": "^0.6.17",
     "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-connect": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom-social-firebase",
   "description": "Firebase Social Provider for freedomjs",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/freedomjs/freedom-social-firebase.git"
@@ -11,9 +11,9 @@
   },
   "homepage": "https://github.com/freedomjs/freedom-social-firebase",
   "devDependencies": {
-    "freedom": "^0.6.21",
-    "freedom-for-chrome": "^0.4.15",
-    "freedom-for-firefox": "^0.6.9",
+    "freedom": "^0.6.26",
+    "freedom-for-chrome": "^0.4.20",
+    "freedom-for-firefox": "^0.6.15",
     "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-connect": "^0.9.0",

--- a/src/facebook-social-provider.js
+++ b/src/facebook-social-provider.js
@@ -59,7 +59,7 @@ FacebookSocialProvider.prototype.getOAuthTokenInteractive_ =
     }
     return accessToken;
   }.bind(this)).catch(function (err) {
-    return Promise.reject('Login error: ' + err.message);
+    return Promise.reject('Login error: ' + err);
   });
 };
 

--- a/src/facebook-social-provider.js
+++ b/src/facebook-social-provider.js
@@ -51,7 +51,7 @@ FacebookSocialProvider.prototype.getOAuthTokenInteractive_ =
                 "&redirect_uri=" + encodeURIComponent(stateObj.redirect) +
                 "&state=" + encodeURIComponent(stateObj.state) +
                 "&response_type=token";
-    return oauth.launchAuthFlow(url, stateObj);
+    return oauth.launchAuthFlow(url, stateObj, loginOpts.interactive);
   }).then(function(responseUrl) {
     var accessToken = responseUrl.match(/access_token=([^&]+)/)[1];
     if (loginOpts.rememberLogin) {

--- a/src/firebase-social-provider.js
+++ b/src/firebase-social-provider.js
@@ -80,6 +80,8 @@ FirebaseSocialProvider.prototype.login = function(loginOpts) {
 
         this.loadContacts_();
       }.bind(this));  // end of authWithOAuthToken
+    }.bind(this)).catch(function(error) {
+      rejectLogin("Login failed");
     }.bind(this));  // end of getOAuthToken_
   }.bind(this));  // end of return new Promise
 };


### PR DESCRIPTION
This is part of a group of pull requests that add a new "interactive" param to the core.oauth launchAuthFlow API.  If this interactive param is false, Chrome + Firefox oauth tabs should open in the background (not be focused).  This results in a better reconnect UX for Facebook.

Related pull requests:
- https://github.com/uProxy/uproxy/pull/1698
- https://github.com/freedomjs/freedom/pull/281
- https://github.com/freedomjs/freedom-for-firefox/pull/70
- https://github.com/freedomjs/freedom-for-chrome/pull/78
