### PR TITLE
Support UTF8 emails for Google social provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom-social-firebase",
   "description": "Firebase Social Provider for freedomjs",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/freedomjs/freedom-social-firebase.git"

--- a/src/google-social-provider.js
+++ b/src/google-social-provider.js
@@ -49,12 +49,13 @@ GoogleSocialProvider.prototype.sendEmail = function(to, subject, body) {
   if (!this.loginState_) {
     throw 'Not signed in';
   }
-  var email ='"Content-Type: text/plain; charset="us-ascii"\n' +
+  var email ='"Content-Type: text/plain; charset="utf-8"\n' +
       'MIME-Version: 1.0\n' +
-      'Content-Transfer-Encoding: 7bit\n' +
+      'Content-Transfer-Encoding: base64\n' +
       'to: ' + to + '\n' +
       'from: ' + this.loginState_.authData[this.networkName_].email + '\n' +
-      'subject: ' + subject + '\n\n' + body;
+      'subject: =?UTF-8?B?' + btoa(unescape(encodeURIComponent(subject))) +
+      '?=\n\n' + btoa(unescape(encodeURIComponent(body)));
   return this.googlePost_('gmail/v1/users/me/messages/send',
       JSON.stringify({raw: btoa(email)}))
       .then(function() {

--- a/src/google-social-provider.js
+++ b/src/google-social-provider.js
@@ -49,13 +49,16 @@ GoogleSocialProvider.prototype.sendEmail = function(to, subject, body) {
   if (!this.loginState_) {
     throw 'Not signed in';
   }
+  function utf8ToBase64(utf8String) {
+    return btoa(unescape(encodeURIComponent(utf8String)));
+  }
   var email ='"Content-Type: text/plain; charset="utf-8"\n' +
       'MIME-Version: 1.0\n' +
       'Content-Transfer-Encoding: base64\n' +
       'to: ' + to + '\n' +
       'from: ' + this.loginState_.authData[this.networkName_].email + '\n' +
-      'subject: =?UTF-8?B?' + btoa(unescape(encodeURIComponent(subject))) +
-      '?=\n\n' + btoa(unescape(encodeURIComponent(body)));
+      'subject: =?UTF-8?B?' + utf8ToBase64(subject) + '?=\n\n' +
+      utf8ToBase64(body);
   return this.googlePost_('gmail/v1/users/me/messages/send',
       JSON.stringify({raw: btoa(email)}))
       .then(function() {


### PR DESCRIPTION
Support UTF8 emails for Google social provider, tested by sending Arabic UTF8 characters for both subject and body
