### PR TITLE
Fix base64 encoding for sending emails

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom-social-firebase",
   "description": "Firebase Social Provider for freedomjs",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/freedomjs/freedom-social-firebase.git"

--- a/src/google-social-provider.js
+++ b/src/google-social-provider.js
@@ -49,8 +49,11 @@ GoogleSocialProvider.prototype.sendEmail = function(to, subject, body) {
   if (!this.loginState_) {
     throw 'Not signed in';
   }
+  function strToBase64(str) {
+    return btoa(str).replace(/\//g,'_').replace(/\+/g,'-');
+  }
   function utf8ToBase64(utf8String) {
-    return btoa(unescape(encodeURIComponent(utf8String)));
+    return strToBase64(unescape(encodeURIComponent(utf8String)));
   }
   var email ='"Content-Type: text/plain; charset="utf-8"\n' +
       'MIME-Version: 1.0\n' +
@@ -60,7 +63,7 @@ GoogleSocialProvider.prototype.sendEmail = function(to, subject, body) {
       'subject: =?UTF-8?B?' + utf8ToBase64(subject) + '?=\n\n' +
       utf8ToBase64(body);
   return this.googlePost_('gmail/v1/users/me/messages/send',
-      JSON.stringify({raw: btoa(email)}))
+      JSON.stringify({raw: strToBase64(email)}))
       .then(function() {
         // Return Promise<void> to match sendEmail definition.
         return Promise.resolve();


### PR DESCRIPTION
Fix base64 encoding for sending emails - Google's email API requires that base64 encoding use _ instead of / and - instead of +

Tested sending email from my GMail account, which previously failed due to a / character, now works
