### PR TITLE
Fix email so it works with both HTML and translations (UTF8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom-social-firebase",
   "description": "Firebase Social Provider for freedomjs",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/freedomjs/freedom-social-firebase.git"

--- a/src/google-social-provider.js
+++ b/src/google-social-provider.js
@@ -55,15 +55,14 @@ GoogleSocialProvider.prototype.sendEmail = function(to, subject, body) {
   function utf8ToBase64(utf8String) {
     return strToBase64(unescape(encodeURIComponent(utf8String)));
   }
-  var email ='"Content-Type: text/plain; charset="utf-8"\n' +
+  var email ='Content-Type: text/html; charset="utf-8"\n' +
       'MIME-Version: 1.0\n' +
-      'Content-Transfer-Encoding: base64\n' +
       'to: ' + to + '\n' +
       'from: ' + this.loginState_.authData[this.networkName_].email + '\n' +
       'subject: =?UTF-8?B?' + utf8ToBase64(subject) + '?=\n\n' +
-      utf8ToBase64(body);
+      body;
   return this.googlePost_('gmail/v1/users/me/messages/send',
-      JSON.stringify({raw: strToBase64(email)}))
+      JSON.stringify({raw: utf8ToBase64(email)}))
       .then(function() {
         // Return Promise<void> to match sendEmail definition.
         return Promise.resolve();


### PR DESCRIPTION
Fix email so it works with both HTML and translations (UTF8)

Tested with both utf8 (Arabic characters) and new HTML from uProxy
