### PR TITLE
Fix missing profile links

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom-social-firebase",
   "description": "Firebase Social Provider for freedomjs",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/freedomjs/freedom-social-firebase.git"

--- a/src/firebase-social-provider.js
+++ b/src/firebase-social-provider.js
@@ -361,6 +361,7 @@ FirebaseSocialProvider.prototype.readFriendProfile_ = function(friendUserId) {
       return F({
           userId: friendUserId,
           name: snapshot.val().name,
+          url: snapshot.val().url,
           imageData: snapshot.val().imageData
       });
     }.bind(this), function(error) {
@@ -499,7 +500,11 @@ FirebaseSocialProvider.prototype.authenticate_ =
         // Set logged in users profile.
         var profileRef =
             new Firebase(this.allUsersUrl_ + '/' + authData.uid + '/profile');
-        profileRef.update({name: name, imageData: this.getMyImage_()});
+        profileRef.update({
+          name: name,
+          imageData: this.getMyImage_(),
+          url: authData[this.networkName_].cachedUserProfile.link || ''
+        });
 
         fulfill(authData);
       }.bind(this));


### PR DESCRIPTION
Fixes https://github.com/uProxy/uproxy/issues/2303, along with https://github.com/uProxy/uproxy/pull/2363

Profile URLs were no longer properly retrieved after changes to add invites.  Now we get profile URLs the same way we get images, by having each logged in user post their own URL to their .../profile/ location on the Firebase server.

Tested in Chrome w/ Gmail and Facebook networks.

Note after this fix, you will still only see profiles for users who have logged in after getting the fix.  i.e. if Alice and Bob are already friends, and Alice logs in with this fix, then afterwards Bob logs in with this fix, Bob will see Alice's profile, but Alice still won't see Bob's profile under after logging out then logging back in again.
